### PR TITLE
dl/implmented run-based train and validation split

### DIFF
--- a/src/inspect_runs.py
+++ b/src/inspect_runs.py
@@ -1,0 +1,69 @@
+"""
+Diagnostic script: inspects the raw annotations of a subject's GDF file to confirm
+how motor imagery trials are organized into runs.
+
+We work with plain Python lists/loops here instead of numpy vectorized comparisons
+on raw.annotations.description -- a numpy "inhomogeneous shape" error showed up when
+comparing that array directly, likely a quirk of how MNE's GDF reader structures the
+annotations for this specific dataset. Plain iteration sidesteps it entirely, and is
+just as fast for a few hundred annotations.
+
+We also now distinguish "any 32766 boundary" (includes EOG calibration blocks, e.g.
+eyes open/closed) from "runs that actually contain motor imagery cues" -- only the
+second group matters for the train/validation split.
+"""
+
+from collections import Counter
+from data_loader import DataLoader
+
+
+def inspect_runs(subject_id: int, training: bool = True):
+    loader = DataLoader()
+    raw, _ = loader.load_session(subject_id, training=training)
+
+    onsets = raw.annotations.onset
+    descriptions = raw.annotations.description
+    pairs = list(zip(onsets, descriptions))
+
+    code_counts = Counter(desc for _, desc in pairs)
+    print(f"\nSubject {subject_id} - all annotation codes found")
+    for code, count in sorted(code_counts.items()):
+        print(f"  {code}: {count}")
+
+    run_marker = '32766'
+    cue_codes = {'769', '770', '771', '772'}
+
+    if run_marker not in code_counts:
+        print(f"\nWARNING: run marker '{run_marker}' not found for subject {subject_id}.")
+        return None
+
+    run_start_times = sorted(onset for onset, desc in pairs if desc == run_marker)
+    cue_times = sorted(onset for onset, desc in pairs if desc in cue_codes)
+
+    print(f"\nTotal '32766' boundaries: {len(run_start_times)} "
+          f"(includes non-motor-imagery blocks like eyes-open/closed/eye-movement).")
+
+    # Assign each cue to the run boundary immediately before it.
+    run_ids = []
+    for t in cue_times:
+        run_id = sum(1 for rs in run_start_times if rs <= t) - 1
+        run_ids.append(run_id)
+
+    trials_per_run = Counter(run_ids)
+    print(f"Trials per boundary-block for subject {subject_id} (run_id: trial_count):")
+    for run_id in sorted(trials_per_run):
+        print(f"  Run {run_id}: {trials_per_run[run_id]} trials")
+
+    # Only boundaries that actually contain cue trials are real motor imagery runs.
+    # EOG calibration blocks will simply not appear here (0 cues assigned to them).
+    print(f"Motor imagery runs (non-empty): {len(trials_per_run)}")
+
+    return trials_per_run
+
+
+if __name__ == "__main__":
+    for subject_id in range(1, 10):
+        try:
+            inspect_runs(subject_id)
+        except Exception as e:
+            print(f"Subject {subject_id} FAILED: {e}")

--- a/src/split.py
+++ b/src/split.py
@@ -1,0 +1,94 @@
+"""
+Run-based train/validation split for the BCI IV 2a Motor Imagery Data.
+
+baseline.py uses a random ShuffleSplit at the TRIAL level, which is fine for CSP+LDA
+(and shouldn't be changed, to keep prior baseline results comparable). For EEGNet,
+a random trial-level split risks leakage: trials recorded in the same run are
+temporally close and can share confounds (electrode drift, fatigue, etc.), so a 
+random split can make validation accuracy look better than it would on genuinely
+unseen data.
+
+We confirmed via inspect_runs.py that every subject has exactly 6 motor imagery runs
+of 48 trials each (some subjects also have 1-3 extra EOG calibration blocks before 
+the runs, which we exclude here since they contain no motor imagery cues).
+
+This module provides:
+    - get_motor_imagery_run_ids(): recovers which run (0-5) each epoch/trial belongs to,
+    directly from the raw annotation (the .fif epoch cache doesn't store this by
+    default, so this needs the original 'raw' object, not just 'epochs').
+    - run_based_splits(): wraps sklearn's GroupKFold so each fold holds out one ENTIRE run
+    for validation, never mixing trials from the same run across train/validation.
+"""
+
+import bisect
+import numpy as np
+from sklearn.model_selection import GroupKFold
+
+from data_loader import DataLoader
+
+def get_motor_imagery_run_ids(raw, cue_codes=('769', '770', '771', '772'), run_marker='32766'):
+    """
+    Returns a run_id (0-5) each motor imagery cue/trial in 'raw' in chronological order, matching
+    the order mne.Epochs will produce when built from the same raw object and the same cue codes.
+
+    Any '32766' boundary that isn't followed by cue trials (e.g. EOG calibration blocks) is
+    automatically excludes: we only assign run numbers based on boundaries that actually
+    contains cues, then renumber then 0-5 in order.
+    """
+
+    onsets = raw.annotations.onset
+    descriptions = list(raw.annotations.description)
+
+    boundary_times = sorted(onsets[i] for i, d in enumerate(descriptions) if d== run_marker)
+    cue_times = sorted(onsets[i] for i, d in enumerate(descriptions) if d in cue_codes)
+
+    if not boundary_times:
+        raise ValueError(f"No '{run_marker}' run boundaries found in this recording.")
+
+    # For each cue, find which boundary it falls after (bisect_right - 1 gives the
+    # index of the last boundary at or before cue's onset time.)
+    absolute_run_id = [bisect.bisect_right(boundary_times, t) - 1 for t in cue_times]
+
+    # Only boundaries that actually have cues assigned to then are real MI runs.
+    # Renumber those, in chronological order, to a clean 0..5 range, this is what makes
+    # subject 4 (fewer calibration blocks, different abosolute boundary indices)
+    # line up with every other subject.
+    ids_with_cues_in_order = sorted(set(absolute_run_id))
+    remap = {old: new for new, old in enumerate(ids_with_cues_in_order)}
+    run_ids = np.array([remap[r] for r in absolute_run_id])
+
+    return run_ids
+
+def run_based_splits(run_ids):
+    """
+    Yields (train_idx, val_idx) pairs, one per unique run, using sklearn's
+    GroupKFold so each holds out one entire run for validation, no trial
+    from that run appears in training for that fold.
+
+    n_splits is set to the number of unique runs (6 for this dataset), giving
+    a leave-one-run-out cross-validation. The run-based analogue of baseline.py's
+    10x ShuffleSplit.
+    """
+    n_runs = len(np.unique(run_ids))
+    gfk = GroupKFold(n_splits=n_runs)
+
+    # X is required by sklearn's API but unique for the split logic itselt
+    # GroupdKFold only looks at groups. We pass a dummy array if the right length.
+    dummy_X = np.zeros(len(run_ids))
+
+    return gfk.split(dummy_X, groups=run_ids)
+
+# test block
+if __name__ == "__main__":
+    loader = DataLoader()
+    raw, _ = loader.load_session(1, training=True)
+
+    run_ids = get_motor_imagery_run_ids(raw)
+    print(f"Found {len(run_ids)} motor imagery trials across {len(np.unique(run_ids))}")
+    print(f"Trials per run: {np.bincount(run_ids)}")
+
+    print("\nRun based Split (leave-one-run-out)")
+    for fold, (train_idx, val_idx) in enumerate(run_based_splits(run_ids)):
+        val_runs = np.unique(run_ids[val_idx])
+        print(f"Fold {fold}: train{len(train_idx)} trials, val={len(val_idx)} trials "
+              f"val run(s): {val_runs.tolist()}")


### PR DESCRIPTION
Add `src/split.py' implemented a one-leave-run-out via GroupKFold to replace the random trial-level `ShuffleSplit` for future deep learning training. Prevents leakage between trials recorded in the same run.

- `get_motor_imagery_run_ids()`:  recovers run membership (0–5) for each trial directly from raw annotations, using the 32766 boundary marker.
- `run_based_splits()`: wraps GroupKFold to hold out one full run per fold.

Verified across all 9 subjects: every subject has exactly 6 motor imagery runs of 48 trials each (confirmed via inspect_runs.py). Subject 4 has fewer 32766 boundaries overall (7 vs. 9) because it's missing some EOG calibration blocks, but still has the same 6 MI runs — handled automatically by renumbering only boundaries that contain cue trials.

Does not affect baseline.py or existing CSP+LDA results,  this split is additive, for EEGNet only

close #13 